### PR TITLE
app.js: move hard coded sessionSecret to config

### DIFF
--- a/app.js
+++ b/app.js
@@ -44,6 +44,7 @@ function onError(error) {
 function stopDB(done) {
     mongoose.disconnect(done)
 }
+
 function createServer(config) {
     var stripe = stripeMod(config.stripeSecretKey);
     //after importing the session package
@@ -91,7 +92,7 @@ function createServer(config) {
     //sessions
     //defaults are true - session saved even if not initialized
     app.use(session({
-            secret: "mycarnivale", resave: false, saveUninitialized: false,
+            secret: config.sessionSecret, resave: false, saveUninitialized: false,
             store: new MongoStore({ mongooseConnection: mongoose.connection }),
             cookie: { maxAge: 180 * 60 * 1000 }//how long session lasts before it expires
         })
@@ -177,6 +178,10 @@ function createServer(config) {
 }
 
 function startServer(config) {
+    if (!config.sessionSecret) {
+        throw new Error("sessionSecret missing from config");
+    }
+
     // Connect to MongoDB
     return mongoose
         .connect(config.mongoURI, { useNewUrlParser: true })

--- a/config/config.js
+++ b/config/config.js
@@ -1,6 +1,7 @@
 module.exports = {
     mongoURI: 'mongodb://localhost:27017/ibcss',
 //        'mongodb+srv://petyus:12345@petyus01-a0req.mongodb.net/ibcss?retryWrites=true&w=majority',
+    sessionSecret: process.env.SESSION_SECRET,
     stripePublishableKey: process.env.STRIPE_PUBLISHABLE_KEY,
     stripeSecretKey: process.env.STRIPE_SECRET_KEY
 };

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -1,0 +1,40 @@
+"use strict";
+const assert = require('assert');
+const app = require('../app');
+const TEST_DEBUG = process.env.TEST_DEBUG || false;
+
+describe('app', function() {
+    it('throws if sessionSecret is missing', function testPath(done) {
+        assert.throws(function () {
+            app({
+                mongoURI: "mongodb://localhost:27017/ibcss",
+            })
+        }, "sessionSecret missing");
+        done();
+    });
+
+    it('throws if sessionSecret is null/empty', function testPath(done) {
+        assert.throws(function () {
+            app({
+                mongoURI: "mongodb://localhost:27017/ibcss",
+                sessionSecret: null,
+            })
+        }, "sessionSecret missing");
+        done();
+    });
+
+    it('accepts non empty secret', function testPath(done) {
+        // This test will start a server instance, don't forget to close
+        assert.doesNotThrow(function () {
+            app({
+                mongoURI: "mongodb://localhost:27017/ibcss",
+                sessionSecret: "abc",
+            })
+                .then(function(server) {
+                    app.stopDB()
+                    server.close()
+                    done()
+                });
+        });
+    });
+});

--- a/test/controller/index.test.js
+++ b/test/controller/index.test.js
@@ -4,6 +4,11 @@ const mongoose = require('mongoose');
 var Blog = require("../../models/blog.model");
 var TEST_DEBUG = process.env.TEST_DEBUG || false;
 
+var config = {
+    mongoURI: "mongodb://localhost:27017/ibcss",
+    sessionSecret: "testing-mycarnivale"
+};
+
 function testDebug(msg) {
     if (TEST_DEBUG) {
         console.log(msg)
@@ -20,9 +25,7 @@ function expectBodyIncludes(stringToMatch) {
 describe('the app', function() {
     var app;
     var server;
-    var config = {
-        mongoURI: "mongodb://localhost:27017/ibcss",
-    };
+
     beforeEach(function () {
         app = require('../../app');
         return app(config)
@@ -46,9 +49,7 @@ describe('the app', function() {
 describe('home page', function () {
     var app;
     var server;
-    var config = {
-        mongoURI: "mongodb://localhost:27017/ibcss",
-    };
+
     beforeEach(function () {
         app = require('../../app');
         return app(config)
@@ -97,9 +98,6 @@ describe('home page', function () {
 describe('home page with live db', function () {
     var app;
     var server;
-    var config = {
-        mongoURI: "mongodb://localhost:27017/ibcss",
-    };
 
     beforeEach(function () {
         app = require('../../app');
@@ -115,8 +113,8 @@ describe('home page with live db', function () {
         done()
     });
 
-    it('responds to / with blogs', function testSlash(done) {
-        mongoose.createConnection(config.mongoURI, {
+    it('responds to / with blogs', function testSlash() {
+        return mongoose.createConnection(config.mongoURI, {
             useNewUrlParser: true
         })
             .then(() => {
@@ -146,7 +144,7 @@ describe('home page with live db', function () {
             })
             .then(() => {
                 testDebug("Start test");
-                request(server)
+                return request(server)
                     .get('/')
                     .expect(expectBodyIncludes("Welcome to the Irish Cactus and Succulent Society Website"))
                     .expect(expectBodyIncludes("Announcing new website"))
@@ -155,7 +153,7 @@ describe('home page with live db', function () {
                     .expect(expectBodyIncludes("Announcing 2019 cactus show"))
                     .expect(expectBodyIncludes("Thanks to the Botanical Gardens for hosting it"))
                     .expect(expectBodyIncludes("Admin2"))
-                    .expect(200, done);
+                    .expect(200);
             })
             .catch((err) => {
                 testDebug(err);


### PR DESCRIPTION
This PR makes it so the session secret is passed via environment variable `SESSION_SECRET` via the config file.

Summary:
 - startServer: throw an exception if starting the application with a secret (this generates a notice currently, but we should exit immediately)
 - startServer: use sessionSecret passed via config
 - test: app.js initialize throws sessionSecret is undefined/null
 - test: app.js successfully starts when sessionSecret is provided