### PR TITLE
Calendar

### DIFF
--- a/app.js
+++ b/app.js
@@ -77,7 +77,10 @@ function createServer(config) {
                 var operators = {
                     'eq': function(l,r) { return l == r; },
                     'noteq': function(l,r) { return l != r; },
+                    'lt': function(l,r) { return Number(l) < Number(r); },
+                    'lte': function(l,r) { return Number(l) <= Number(r); },
                     'gt': function(l,r) { return Number(l) > Number(r); },
+                    'gte': function(l,r) { return Number(l) >= Number(r); },
                     'or': function(l,r) { return l || r; },
                     'and': function(l,r) { return l && r; },
                     '%': function(l,r) { return (l % r) === 0; }

--- a/app.js
+++ b/app.js
@@ -72,7 +72,20 @@ function createServer(config) {
         defaultLayout: "layout",
         extname: ".hbs",
         helpers: {
-            intToMonth: DateUtil.intToMonth
+            intToMonth: DateUtil.intToMonth,
+            when: function(operand_1, operator, operand_2, options) {
+                var operators = {
+                    'eq': function(l,r) { return l == r; },
+                    'noteq': function(l,r) { return l != r; },
+                    'gt': function(l,r) { return Number(l) > Number(r); },
+                    'or': function(l,r) { return l || r; },
+                    'and': function(l,r) { return l && r; },
+                    '%': function(l,r) { return (l % r) === 0; }
+                }
+                    , result = operators[operator](operand_1,operand_2);
+                if (result) return options.fn(this);
+                else  return options.inverse(this);
+            },
         }
     });
 

--- a/app.js
+++ b/app.js
@@ -13,9 +13,10 @@ var methodOverride = require('method-override');
 const mongoose = require("mongoose");
 const bodyParser = require("body-parser");
 const stripeMod = require('stripe');
+let DateUtil = require('./lib/dateutil');
 var cookieParser = require('cookie-parser');
 var logger = require('morgan');
-var expressHbs = require("express-handlebars");
+let expressHbs = require("express-handlebars");
 
 // DB Config
 function onError(error) {
@@ -66,9 +67,17 @@ function createServer(config) {
     app.set('views', path.join(__dirname, 'views'));
 
     // view engine setup
-    app.engine(".hbs", expressHbs({ defaultLayout: "layout", extname: ".hbs" }));
-    app.set('view engine', '.hbs');
 
+    let hbs = expressHbs.create({
+        defaultLayout: "layout",
+        extname: ".hbs",
+        helpers: {
+            intToMonth: DateUtil.intToMonth
+        }
+    });
+
+    app.engine(".hbs", hbs.engine);
+    app.set('view engine', '.hbs');
 
     //get body parser from https://github.com/expressjs/body-parser
     // parse application/x-www-form-urlencoded
@@ -176,6 +185,9 @@ function createServer(config) {
             : 'port ' + addr.port;
         debug('Listening on ' + bind);
     });
+
+
+
     return server;
 }
 

--- a/controllers/admin/calendar.controller.js
+++ b/controllers/admin/calendar.controller.js
@@ -1,8 +1,101 @@
 const Calendar = require('../../models/calendar.model');
+const moment = require('moment');
 
 let CalendarController = {};
-CalendarController.index = function (req, res, next) {
-    res.render('admin/calendar/index', { title: 'Index' });
+CalendarController.index = function (req, res) {
+    let year = moment().year();
+    res.redirect("/admin/calendar/"+year)
+};
+
+CalendarController.edit = function (req, res, next) {
+    if (typeof req.params.year == "undefined") {
+        res.redirect("/admin/calendar");
+        return
+    }
+    let year = req.params.year;
+    if (year.length !== 4) {
+        throw new Error("invalid year")
+    }
+
+    // Fetch years calendar, or create default unpublished entries
+    let opt = {sort: "month"};
+    let query = Calendar.find({year: year});
+    let promise = query.exec();
+    promise.then(function (entries) {
+        if (entries.length === 0) {
+            let created = [];
+            for (let i = 1; i < 13; i++) {
+                let entry = new Calendar({
+                    month: i,
+                    year: year,
+                    published: false,
+                    title: "",
+                    description: "",
+                });
+                created.push(entry.save());
+            }
+            return Promise.all(created);
+        } else if (entries.length !== 12) {
+            next(new Error("Calendar in an invalid state"))
+        } else {
+            return entries
+        }
+    }, function (err) {
+        throw err;
+    })
+        .then(function (entries) {
+            // Render page with calendar entries
+            res.render('admin/calendar/edit', {
+                title: 'Manage Calendar',
+                layout: false,
+                calendar: entries,
+                year: year
+            });
+        })
+};
+
+// Update request. We'll have an array of calendar objects coming in.
+// Ensure we haven't lost/gained anything.
+CalendarController.submitEdit = function (req, res, next) {
+    let year = req.params.year;
+    let query = Calendar.find({year: year});
+    query.exec()
+        .then(function (entries) {
+        if (entries.length === 0) {
+            throw new Error("calendar does not exist");
+        } else if (req.body.calendar.length !== entries.length) {
+            throw new Error("missing form fields")
+        }
+
+        // Iterate over entries and apply updates
+        let updates = [];
+        for (let i = 0; i < entries.length - 1; i++) {
+            let entry = entries[i];
+            let formEntry = req.body.calendar[i];
+
+            // published is checkbox, which is omitted if not set.
+            let published = typeof formEntry.published != "undefined";
+            if (entry.published !== published) {
+                entry.published = published
+            }
+            if (entry.title !== formEntry.title) {
+                entry.title = formEntry.title
+            }
+            if (entry.description !== formEntry.description) {
+                entry.description = formEntry.description
+            }
+            updates.push(entry.save())
+        }
+        return Promise.all(updates)
+    }, function (err) {
+        throw err;
+    })
+        .then(function () {
+            // Redirect to manage view
+            res.redirect('/admin/calendar/' + year);
+        }, function (err) {
+            throw err;
+        });
 };
 
 module.exports = CalendarController;

--- a/controllers/admin/calendar.controller.js
+++ b/controllers/admin/calendar.controller.js
@@ -1,19 +1,5 @@
-const Calendar = require('../../models/calendar.model');
+const CalendarUtil = require('../../lib/calendar');
 const moment = require('moment');
-
-function getYearSchedule(year) {
-    return Calendar.find(
-        {
-            year: year
-        },
-        undefined,
-        {
-            sort: {
-                month: 1
-            }
-        })
-        .exec();
-}
 
 let CalendarController = {};
 CalendarController.index = function (req, res) {
@@ -21,7 +7,7 @@ CalendarController.index = function (req, res) {
     res.redirect("/admin/calendar/"+year)
 };
 
-CalendarController.edit = function (req, res, next) {
+CalendarController.edit = function (req, res) {
     if (typeof req.params.year == "undefined") {
         res.redirect("/admin/calendar");
         return
@@ -31,36 +17,40 @@ CalendarController.edit = function (req, res, next) {
         throw new Error("invalid year")
     }
 
+    // 2nd Thursday of each month, at 7.30pm
+    // later: allow overriding these via configuration
+    let defaultNthDay = 2;
+    let defaultWeekday = 'Thursday';
+    let defaultHour = 19;
+    let defaultMinute = 30;
+
     // Fetch years calendar, or create default unpublished entries
-    getYearSchedule(year)
+    CalendarUtil.getYearSchedule(year)
         .then(function (entries) {
-        if (entries.length === 0) {
-            let created = [];
-            for (let i = 0; i < 12; i++) {
-                let entry = new Calendar({
-                    month: i,
-                    year: year,
-                    published: false,
-                    title: "",
-                    description: "",
-                });
-                created.push(entry.save());
+            if (entries.length === 0) {
+                let promises = CalendarUtil.generateYearSchedule(year, defaultNthDay, defaultWeekday, defaultHour, defaultMinute)
+                    .map(function (obj) {
+                        return obj.save();
+                    });
+                return Promise.all(promises);
+            } else if (entries.length !== 12) {
+                throw new Error("Calendar in an invalid state");
+            } else {
+                return entries
             }
-            return Promise.all(created);
-        } else if (entries.length !== 12) {
-            next(new Error("Calendar in an invalid state"))
-        } else {
-            return entries
-        }
-    }, function (err) {
-        throw err;
-    })
+        }, function (err) {
+            throw err;
+        })
         .then(function (entries) {
+            let timeInfo = entries.map(function (entry) {
+                return CalendarUtil.createTimeInfo(entry.timestamp);
+            });
             // Render page with calendar entries
             res.render('admin/calendar/edit', {
                 title: 'Manage Calendar',
                 layout: false,
                 calendar: entries,
+                timeInfo: timeInfo,
                 year: year
             });
         })
@@ -70,37 +60,37 @@ CalendarController.edit = function (req, res, next) {
 // Ensure we haven't lost/gained anything.
 CalendarController.submitEdit = function (req, res, next) {
     let year = req.params.year;
-    getYearSchedule(year)
+    CalendarUtil.getYearSchedule(year)
         .then(function (entries) {
-        if (entries.length === 0) {
-            throw new Error("calendar does not exist");
-        } else if (req.body.calendar.length !== entries.length) {
-            throw new Error("missing form fields")
-        }
+            if (entries.length === 0) {
+                throw new Error("calendar does not exist");
+            } else if (req.body.calendar.length !== entries.length) {
+                throw new Error("missing form fields")
+            }
 
-        // Iterate over entries and apply updates
-        let updates = [];
-        for (let i = 0; i < entries.length - 1; i++) {
-            let entry = entries[i];
-            let formEntry = req.body.calendar[i];
+            // Iterate over entries and apply updates
+            let updates = [];
+            for (let i = 0; i < entries.length - 1; i++) {
+                let entry = entries[i];
+                let formEntry = req.body.calendar[i];
 
-            // published is checkbox, which is omitted if not set.
-            let published = typeof formEntry.published != "undefined";
-            if (entry.published !== published) {
-                entry.published = published
+                // published is checkbox, which is omitted if not set.
+                let published = typeof formEntry.published != "undefined";
+                if (entry.published !== published) {
+                    entry.published = published
+                }
+                if (entry.title !== formEntry.title) {
+                    entry.title = formEntry.title
+                }
+                if (entry.description !== formEntry.description) {
+                    entry.description = formEntry.description
+                }
+                updates.push(entry.save())
             }
-            if (entry.title !== formEntry.title) {
-                entry.title = formEntry.title
-            }
-            if (entry.description !== formEntry.description) {
-                entry.description = formEntry.description
-            }
-            updates.push(entry.save())
-        }
-        return Promise.all(updates)
-    }, function (err) {
-        throw err;
-    })
+            return Promise.all(updates)
+        }, function (err) {
+            throw err;
+        })
         .then(function () {
             // Redirect to manage view
             res.redirect('/admin/calendar/' + year);

--- a/controllers/admin/calendar.controller.js
+++ b/controllers/admin/calendar.controller.js
@@ -1,6 +1,20 @@
 const Calendar = require('../../models/calendar.model');
 const moment = require('moment');
 
+function getYearSchedule(year) {
+    return Calendar.find(
+        {
+            year: year
+        },
+        undefined,
+        {
+            sort: {
+                month: 1
+            }
+        })
+        .exec();
+}
+
 let CalendarController = {};
 CalendarController.index = function (req, res) {
     let year = moment().year();
@@ -18,13 +32,11 @@ CalendarController.edit = function (req, res, next) {
     }
 
     // Fetch years calendar, or create default unpublished entries
-    let opt = {sort: "month"};
-    let query = Calendar.find({year: year});
-    let promise = query.exec();
-    promise.then(function (entries) {
+    getYearSchedule(year)
+        .then(function (entries) {
         if (entries.length === 0) {
             let created = [];
-            for (let i = 1; i < 13; i++) {
+            for (let i = 0; i < 12; i++) {
                 let entry = new Calendar({
                     month: i,
                     year: year,
@@ -58,8 +70,7 @@ CalendarController.edit = function (req, res, next) {
 // Ensure we haven't lost/gained anything.
 CalendarController.submitEdit = function (req, res, next) {
     let year = req.params.year;
-    let query = Calendar.find({year: year});
-    query.exec()
+    getYearSchedule(year)
         .then(function (entries) {
         if (entries.length === 0) {
             throw new Error("calendar does not exist");

--- a/controllers/admin/calendar.controller.js
+++ b/controllers/admin/calendar.controller.js
@@ -53,7 +53,7 @@ CalendarController.edit = function (req, res) {
                 timeInfo: timeInfo,
                 year: year
             });
-        })
+        });
 };
 
 // Update request. We'll have an array of calendar objects coming in.

--- a/controllers/admin/calendar.controller.js
+++ b/controllers/admin/calendar.controller.js
@@ -1,0 +1,8 @@
+const Calendar = require('../../models/calendar.model');
+
+let CalendarController = {};
+CalendarController.index = function (req, res, next) {
+    res.render('admin/calendar/index', { title: 'Index' });
+};
+
+module.exports = CalendarController;

--- a/controllers/home.controller.js
+++ b/controllers/home.controller.js
@@ -1,15 +1,42 @@
 const Blog = require('../models/blog.model');
+const Calendar = require('../models/calendar.model');
+const moment = require('moment');
 
 let HomeController = {};
 HomeController.index = function (req, res, next) {
-    Blog.find(function (err, docs) {
-        var blogPosts = [];
-        var postSize = 1;
-        for (var i = 0; i < 3; i += postSize) {
-            blogPosts.push(docs.slice(i, i + postSize));
+    let now = moment();
+    let year = now.year();
+    let month = now.month();
+    let blogs = Blog.find().exec();
+    let schedule = Calendar.find(
+        {
+            year: year,
+            published: true
+        },
+        undefined,
+        {
+            sort: {
+                month: 1
+            }
         }
-        res.render('index', { title: 'Index', blogs: blogPosts });
-    });
+    ).exec();
+    Promise.all([blogs, schedule])
+        .then(function (results) {
+            let docs = results[0];
+            let calendar = results[1];
+            let blogPosts = [];
+            let postSize = 1;
+            for (let i = 0; i < 3; i += postSize) {
+                blogPosts.push(docs.slice(i, i + postSize));
+            }
+            res.render('index', {
+                title: 'Index',
+                blogs: blogPosts,
+                calendar: calendar,
+                currentYear: year,
+                currentMonth: month
+            });
+        });
 };
 
-module.exports = HomeController
+module.exports = HomeController;

--- a/controllers/home.controller.js
+++ b/controllers/home.controller.js
@@ -1,5 +1,5 @@
 const Blog = require('../models/blog.model');
-const Calendar = require('../models/calendar.model');
+const CalendarUtil = require('../lib/calendar');
 const moment = require('moment');
 
 let HomeController = {};
@@ -8,18 +8,7 @@ HomeController.index = function (req, res, next) {
     let year = now.year();
     let month = now.month();
     let blogs = Blog.find().exec();
-    let schedule = Calendar.find(
-        {
-            year: year,
-            published: true
-        },
-        undefined,
-        {
-            sort: {
-                month: 1
-            }
-        }
-    ).exec();
+    let schedule = CalendarUtil.getYearSchedule(year);
     Promise.all([blogs, schedule])
         .then(function (results) {
             let docs = results[0];
@@ -29,10 +18,16 @@ HomeController.index = function (req, res, next) {
             for (let i = 0; i < 3; i += postSize) {
                 blogPosts.push(docs.slice(i, i + postSize));
             }
+
+            let timeInfo = calendar.map(function (entry) {
+                return CalendarUtil.createTimeInfo(entry.timestamp);
+            });
+
             res.render('index', {
                 title: 'Index',
                 blogs: blogPosts,
                 calendar: calendar,
+                timeInfo: timeInfo,
                 currentYear: year,
                 currentMonth: month
             });

--- a/lib/calendar.js
+++ b/lib/calendar.js
@@ -30,8 +30,7 @@ module.exports = {
             .exec();
     },
     /**
-     *
-     * @param Number timestamp - time as moment object
+     * @param timestamp Number
      */
     createTimeInfo: function (timestamp) {
         let time = moment.unix(timestamp);

--- a/lib/calendar.js
+++ b/lib/calendar.js
@@ -1,0 +1,48 @@
+const DateUtil = require('./dateutil');
+const Calendar = require('../models/calendar.model');
+const moment = require('moment');
+
+module.exports = {
+    generateYearSchedule: function(year, nthDay, weekdayAsString, hour, minute) {
+        return DateUtil.generateDates(year, nthDay, weekdayAsString)
+            .map(function (date) {
+                date.minute(minute).hour(hour);
+                return new Calendar({
+                    timestamp: date.unix(),
+                    year: year,
+                    published: false,
+                    title: "",
+                    description: "",
+                });
+            });
+    },
+    getYearSchedule: function (year) {
+        return Calendar.find(
+            {
+                year: year
+            },
+            undefined,
+            {
+                sort: {
+                    timestamp: 1
+                }
+            })
+            .exec();
+    },
+    /**
+     *
+     * @param Number timestamp - time as moment object
+     */
+    createTimeInfo: function (timestamp) {
+        let time = moment.unix(timestamp);
+        return {
+            minute: time.minute(),
+            hour: time.hour(),
+            day: time.day(),
+            dayText: time.format('Do'),
+            month: time.month(),
+            monthText: moment.months()[time.month()],
+            year: time.year()
+        }
+    }
+};

--- a/lib/dateutil.js
+++ b/lib/dateutil.js
@@ -1,0 +1,13 @@
+let months = [
+    "January", "Febuary", "March", "April", "May", "June",
+    "July", "August", "September", "October", "November", "December",
+];
+
+let DateUtil = {};
+DateUtil.intToMonth = function(month) {
+    if (month < 1 || month > 12) {
+        throw new Error("invalid integer value for month")
+    }
+    return months[month-1];
+};
+module.exports = DateUtil;

--- a/lib/dateutil.js
+++ b/lib/dateutil.js
@@ -5,9 +5,9 @@ let months = [
 
 let DateUtil = {};
 DateUtil.intToMonth = function(month) {
-    if (month < 1 || month > 12) {
+    if (month < 0 || month > 11) {
         throw new Error("invalid integer value for month")
     }
-    return months[month-1];
+    return months[month];
 };
 module.exports = DateUtil;

--- a/lib/dateutil.js
+++ b/lib/dateutil.js
@@ -1,3 +1,4 @@
+const moment = require('moment');
 let months = [
     "January", "Febuary", "March", "April", "May", "June",
     "July", "August", "September", "October", "November", "December",
@@ -10,4 +11,22 @@ DateUtil.intToMonth = function(month) {
     }
     return months[month];
 };
+
+DateUtil.generateDates = function(year, nthDay, weekdayAsString) {
+    let weekdayToFind = moment().day(weekdayAsString).weekday();
+    let dates = [];
+    for (let i = 0; i < 12; i++) {
+        let startOfMonth = moment().year(year).month(i).startOf('month');
+        let firstChosenDay = startOfMonth.clone();
+
+        // Advance until first occurance of 'weekdayToFind'.
+        while(firstChosenDay.weekday() !== weekdayToFind) {
+            firstChosenDay.add(1, 'day');
+        }
+        let chosenDay = firstChosenDay.clone().add(nthDay-1, 'week');
+        dates.push(chosenDay)
+    }
+    return dates
+};
+
 module.exports = DateUtil;

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -1,0 +1,29 @@
+
+//need to be logged in to get to some pages
+function isLoggedIn(req, res, next) {
+    if (req.isAuthenticated()) {
+        return next();
+    }
+    res.redirect("/");
+}
+
+//not logged in - check if I am not authenticated
+function notLoggedIn(req, res, next) {
+    if (!req.isAuthenticated()) {
+        return next();
+    }
+    res.redirect("/");
+}
+
+//user is admin
+function isAdmin(req, res, next) {
+    if (req.user.isAdmin)
+        return next();
+    res.redirect('/');
+}
+
+let middleware = {};
+middleware.isLoggedIn = isLoggedIn;
+middleware.notLoggedIn = notLoggedIn;
+middleware.isAdmin = isAdmin;
+module.exports = middleware;

--- a/models/calendar.model.js
+++ b/models/calendar.model.js
@@ -2,13 +2,14 @@ const mongoose = require('mongoose');
 const Schema = mongoose.Schema;
 
 let CalendarSchema = new Schema({
-    month: { type: String, required: true },
-    year: { type: String, required: true },
-    title: { type: String, required: true },
-    description: { type: String, required: true }
+    month: { type: Number, required: true },
+    year: { type: Number, required: true },
+    published: { type: Boolean, required: true },
+    title: { type: String, required: false },
+    description: { type: String, required: false }
 }, {
     timestamps: true
 });
 
 // Export the model
-module.exports = mongoose.model('CalendarSchema', CalendarSchema);
+module.exports = mongoose.model('Calendar', CalendarSchema);

--- a/models/calendar.model.js
+++ b/models/calendar.model.js
@@ -1,0 +1,14 @@
+const mongoose = require('mongoose');
+const Schema = mongoose.Schema;
+
+let CalendarSchema = new Schema({
+    month: { type: String, required: true },
+    year: { type: String, required: true },
+    title: { type: String, required: true },
+    description: { type: String, required: true }
+}, {
+    timestamps: true
+});
+
+// Export the model
+module.exports = mongoose.model('CalendarSchema', CalendarSchema);

--- a/models/calendar.model.js
+++ b/models/calendar.model.js
@@ -2,7 +2,7 @@ const mongoose = require('mongoose');
 const Schema = mongoose.Schema;
 
 let CalendarSchema = new Schema({
-    month: { type: Number, required: true },
+    timestamp: { type: Number, required: true },
     year: { type: Number, required: true },
     published: { type: Boolean, required: true },
     title: { type: String, required: false },

--- a/models/user.model.js
+++ b/models/user.model.js
@@ -19,7 +19,6 @@ userSchema.methods.encryptPassword = function (password) {
 };
 userSchema.methods.validPassword = function (password) {
     return bcrypt.compareSync(password, this.password); //current user
-
 };
 // Export the model
 module.exports = mongoose.model('User', userSchema);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1920,6 +1920,11 @@
         }
       }
     },
+    "moment": {
+      "version": "2.24.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
+      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
+    },
     "mongodb": {
       "version": "3.2.7",
       "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.2.7.tgz",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "hbs": "~4.0.4",
     "http-errors": "~1.6.3",
     "method-override": "^3.0.0",
+    "moment": "^2.24.0",
     "mongoose": "^5.6.0",
     "morgan": "~1.9.1",
     "multer": "^1.4.2",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "start": "node ./bin/www",
-    "test": "mocha -R spec test/*",
+    "test": "mocha -R spec test/* --exit",
     "coverage-test": "nyc --reporter=text mocha -R spec test/*",
     "coverage-test-html": "nyc --reporter=html mocha -R spec test/*"
   },

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "scripts": {
     "start": "node ./bin/www",
     "test": "mocha -R spec test/* --exit",
-    "coverage-test": "nyc --reporter=text mocha -R spec test/*",
-    "coverage-test-html": "nyc --reporter=html mocha -R spec test/*"
+    "coverage-test": "nyc --reporter=text mocha -R spec test/* --exit",
+    "coverage-test-html": "nyc --reporter=html mocha -R spec test/* --exit"
   },
   "dependencies": {
     "bcrypt": "^3.0.6",

--- a/routes/admin.js
+++ b/routes/admin.js
@@ -1,10 +1,14 @@
-var express = require('express');
-var router = express.Router();
-var Product = require("../models/product.model");
-var User = require("../models/user.model");
-var Contact = require("../models/contact.model");
+const express = require('express');
+const router = express.Router();
+const middleware = require('../lib/middleware');
+const Product = require("../models/product.model");
+const User = require("../models/user.model");
+const Contact = require("../models/contact.model");
 const multer = require('multer');
 const upload = multer({dest:'uploads/'});
+
+router.use(middleware.isLoggedIn);
+router.use(middleware.isAdmin);
 
 /* GET home page. */
 router.get('/dashboard', function (req, res) {

--- a/routes/admin.js
+++ b/routes/admin.js
@@ -103,5 +103,7 @@ router.get('/test', contact_controller.test);
 // Calendar
 const CalendarController = require('../controllers/admin/calendar.controller');
 router.get('/calendar', CalendarController.index);
+router.get('/calendar/:year', CalendarController.edit);
+router.post('/calendar/:year', CalendarController.submitEdit);
 
 module.exports = router;

--- a/routes/admin.js
+++ b/routes/admin.js
@@ -73,7 +73,6 @@ router.get('/test', blog_controller.test);
 
 
 //contact
-
 router.get('/allcontacts', function (req, res, next) {
     var successMgs = req.flash('success')[0];
     Contact.find(function (err, docs) {
@@ -86,8 +85,6 @@ router.get('/allcontacts', function (req, res, next) {
     });
 });
 
-
-
 const contact_controller = require('../controllers/contact.controller');
 //might need in future
 //router.post('/create', contact_controller.contact_create);
@@ -99,6 +96,8 @@ router.delete('/contact/:id/delete', contact_controller.contact_delete);
 // a simple test url to check that all of our files are communicating correctly.
 router.get('/test', contact_controller.test);
 
-
+// Calendar
+const CalendarController = require('../controllers/admin/calendar.controller');
+router.get('/calendar', CalendarController.index);
 
 module.exports = router;

--- a/seed/calendar2020.js
+++ b/seed/calendar2020.js
@@ -2,6 +2,7 @@ const CalendarUtil = require("../lib/calendar");
 const mongoose = require("mongoose");
 const moment = require('moment');
 
+// 0 -> Jan, 11 -> Dec
 const info = {
     1: {
         title: "Potting process discussion",
@@ -22,10 +23,6 @@ const info = {
         description: "Bring your ten favourite plants and put them on the bench! This is not competitive but does provide a chance to share plants that are not show-worthy or don’t fit a class. We all have them  so bring them along and make it an interesting evening. It will also help you to get ready for the Show ",
     },
     5: {
-        title: "Potting process discussion",
-        description: "Michael Harrington will take us through the preparation of potting mixes and the potting process with many tips along the way",
-    },
-    6: {
         title: "The Cactus and Succulent Show in the National Botanic Gardens.",
         description: "All hands on deck!\n" +
             "\n" +

--- a/seed/calendar2020.js
+++ b/seed/calendar2020.js
@@ -1,0 +1,65 @@
+const CalendarUtil = require("../lib/calendar");
+const mongoose = require("mongoose");
+const moment = require('moment');
+
+const info = {
+    1: {
+        title: "Potting process discussion",
+        description: "Michael Harrington will take us through the preparation of potting mixes and the potting process with many tips along the way",
+    },
+    2: {
+        title: "Some cacti of Northern Argentina",
+        description: "This remote high altitude environment is home to many endemics. A slide presentation will highlight some of its gems.",
+    },
+    3: {
+        title: "Cactus and Succulent identification",
+        description: "Bring at least five cacti or succulents whose names you don’t know and we’ll do our best! Reference books will be available.\n" +
+            "\n" +
+            "This will only work if you bring plants, so please make the effort.",
+    },
+    4: {
+        title: "Pre-show plants display",
+        description: "Bring your ten favourite plants and put them on the bench! This is not competitive but does provide a chance to share plants that are not show-worthy or don’t fit a class. We all have them  so bring them along and make it an interesting evening. It will also help you to get ready for the Show ",
+    },
+    5: {
+        title: "Potting process discussion",
+        description: "Michael Harrington will take us through the preparation of potting mixes and the potting process with many tips along the way",
+    },
+    6: {
+        title: "The Cactus and Succulent Show in the National Botanic Gardens.",
+        description: "All hands on deck!\n" +
+            "\n" +
+            "Staging from 17:00 to 20:00 on Friday evening and from 9:00 on Saturday morning. Judging commences at 11:00.\n" +
+            "\n" +
+            "There will also be a plant sale.",
+    },
+};
+
+mongoose
+    .connect("mongodb://localhost:27017/ibcss")
+    .then(function () {
+        let year = 2020;
+        let defaultNthDay = 2;
+        let defaultWeekday = 'Thursday';
+        let defaultHour = 19;
+        let defaultMinute = 30;
+
+        let promises = CalendarUtil.generateYearSchedule(year, defaultNthDay, defaultWeekday, defaultHour, defaultMinute)
+            .map((obj) => {
+                let time = moment.unix(obj.timestamp);
+                let month = time.month();
+                if (month in info) {
+                    obj.title = info[month].title;
+                    obj.description = info[month].description;
+                    obj.published = true;
+                } else {
+                    obj.published = false;
+                }
+                return obj.save();
+            });
+
+        Promise.all(promises)
+            .then(function (obj) {
+                mongoose.disconnect();
+            });
+    });

--- a/seed/userSeed.js
+++ b/seed/userSeed.js
@@ -1,0 +1,29 @@
+var User = require("../models/user.model");
+var mongoose = require("mongoose");
+var bcrypt = require("bcrypt-nodejs");
+mongoose.connect("mongodb://localhost:27017/ibcss");
+
+var users = [
+    new User({
+        name: 'admin',
+        email: 'admin@com.localhost',
+        password: bcrypt.hashSync("admin", bcrypt.genSaltSync(5), null),
+        isAdmin: true,
+    })
+];
+
+var done = 0;
+for (var i = 0; i < users.length; i++) {
+    users[i].save(function (err, result) {
+        done++;
+        if (done === users.length) {
+            exit();
+        }
+    });
+}
+
+
+function exit() {
+    mongoose.disconnect();
+
+}

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -31,8 +31,8 @@ describe('app', function() {
                 sessionSecret: "abc",
             })
                 .then(function(server) {
-                    app.stopDB()
-                    server.close()
+                    app.stopDB();
+                    server.close();
                     done()
                 });
         });

--- a/test/controller/user.test.js
+++ b/test/controller/user.test.js
@@ -279,8 +279,8 @@ describe('user', function () {
                     });
             });
 
-            it('unknown user, redirects to login', function testSlash(done) {
-                mongoose.createConnection(config.mongoURI, {
+            it('unknown user, redirects to login', function testSlash() {
+                return mongoose.createConnection(config.mongoURI, {
                     useNewUrlParser: true
                 })
                     .then(() => {
@@ -289,7 +289,7 @@ describe('user', function () {
                     })
                     .then(() => {
                         testDebug("Start test");
-                        request(server)
+                        return request(server)
                             .get('/user/login')
                             .expect(200)
                             .then(function (getres) {
@@ -297,7 +297,7 @@ describe('user', function () {
                                 var csrfToken = $("#_csrf").val();
                                 testDebug("With CSRF token " + csrfToken);
                                 var reqCookie = getres.headers['set-cookie'];
-                                request(server)
+                                return request(server)
                                     .post('/user/login')
                                     .set({cookie: reqCookie})
                                     .send({
@@ -310,9 +310,8 @@ describe('user', function () {
                                             throw new Error("expected redirect to profile page: " + res.header['location'])
                                         }
                                     })
-                                    .expect(302, done);
-                            })
-
+                                    .expect(302);
+                            });
                     })
                     .catch((err) => {
                         testDebug(err);

--- a/views/admin/calendar/edit.hbs
+++ b/views/admin/calendar/edit.hbs
@@ -33,7 +33,13 @@
                     <div class="shop clearfix">
                         <div class="details prc">
                             <p>
-                                {{ intToMonth this.month }}
+                            {{#with (lookup ../timeInfo @index)}}
+                            {{this.hour}}:{{this.minute}}
+                            {{#when this.hour 'gte' 12}}PM{{/when}}
+                            {{#when this.hour 'lte' 12}}AM{{/when}}
+                            {{this.dayText}}
+                            {{this.monthText}}
+                            {{/with}}
                             </p>
                         </div>
                         <div class="details">

--- a/views/admin/calendar/edit.hbs
+++ b/views/admin/calendar/edit.hbs
@@ -1,0 +1,55 @@
+{{>header_nav_admin}}
+<!-- Content Row -->
+<hr />
+<div id="wrapper" class="row">
+    <section class="banner_contact">
+            <div class="onbanner">
+                <h4>{{title}}</h4>
+                <h5>These are all the people who have tried to contact IBCSS, you can edit or delete.</h5>
+            </div>
+        </section>
+        <hr />
+
+        <form method="POST" action="/admin/calendar/{{ year }}">
+            <input type="submit" value="Update">
+            <div class="container">
+                <div class="shop tablehead">
+                    <div class="details">
+                        <p>Month</p>
+                    </div>
+                    <div class="details">
+                        <p>Published</p>
+                    </div>
+                    <div class="details">
+                        <p>Title</p>
+                    </div>
+                    <div class="details">
+                        <p>Description</p>
+                    </div>
+                </div>
+
+                {{#each calendar}}
+                <div class="size products clearfix" style="clear:both">
+                    <div class="shop clearfix">
+                        <div class="details prc">
+                            <p>
+                                {{ intToMonth this.month }}
+                            </p>
+                        </div>
+                        <div class="details">
+                            <input type="checkbox" name="calendar[{{ @index }}][published]" class="form-input" {{#if this.published }}checked {{/if }} />
+                        </div>
+                        <div class="details">
+                            <input type="text" name="calendar[{{ @index }}][title]" value="{{ this.title }}" class="form-input" value="{{ this.title }}"/>
+                        </div>
+                        <div class="details">
+                            <textarea name="calendar[{{ @index }}][description]" class="form-input">{{ this.description }}</textarea>
+                        </div>
+                    </div>
+                </div>
+                {{/each}}
+            </div>
+        </form>
+    </div>
+</div>
+{{>footer_admin}}

--- a/views/index.hbs
+++ b/views/index.hbs
@@ -25,7 +25,7 @@
                     <div class="calendar_date">
                         {{#with (lookup ../timeInfo @index)}}
                         <div class="top-bar">
-                            <h3>the {{this.dayText}} {{this.monthText}}</h3>
+                            <h3>{{this.dayText}} of {{this.monthText}}</h3>
                         </div>
                         <p>
                             {{this.hour}}:{{this.minute}}

--- a/views/index.hbs
+++ b/views/index.hbs
@@ -14,85 +14,31 @@
         <p class="center">
             There are no meetings in January or December.
         </p>
-            <!-- Slide2 -->
-            <div class="wrap-slick2">
-                <div class="slick2">
-                    <div class="item-slick2">
-                        <!-- Block2 -->
-                        <div class="calendar_date">
-                            <div class="top-bar">
-                                <h3> the 2nd May</h3>
-                            </div>
-                            <p>
-                                 7:30 pm
-                            </p>
-                            <p class="meetdescription">
-                                Member Michael Harrington will discuss potting mixes, the potting process, and pass on tips along the way.
-                            </p>
-                        </div>
-                </div>
-
-
+        <!-- Slide2 -->
+        <div class="wrap-slick2">
+            <div class="slick2">
+                {{#each calendar}}
                 <div class="item-slick2">
                     <!-- Block2 -->
                     <div class="calendar_date">
                         <div class="top-bar">
-                            <h3> the 5th August</h3>
+                            <h3>the {{ intToMonth this.month }} {{ this.month }} {{ ../currentMonth }}</h3>
                         </div>
                         <p>
-                            6:30 pm
+                            ~ 6:30 pm
                         </p>
-                        <p class=" meetdescription">
+                        <p class="meetdescription">
                             <strong>
-                                Plant Identification Meet
+                                {{ this.title }}
                             </strong>
 
-                            - bring your mystery plants in and we will do our best
-                        </p>
-
-                    </div>
-                </div>
-
-                <div class="item-slick2">
-                    <!-- Block2 -->
-                    <div class="calendar_date">
-                        <div class="top-bar">
-                            <h3> the 8th September</h3>
-                        </div>
-                        <p>
-                            6:30 pm
-                        </p>
-                        <p class=" meetdescription">
-                            <strong>
-                                Plant Sale
-                            </strong>
-
-                            - Plant sale at the Dublin Botanic Gardens
-                        </p>
-
-                    </div>
-                </div>
-                <div class="item-slick2">
-                    <!-- Block2 -->
-                    <div class="calendar_date">
-                        <div class="top-bar">
-                            <h3>  the 11th December</h3>
-                        </div>
-                        <p>
-                            6:30 pm
-                        </p>
-                        <p class=" meetdescription">
-                            <strong>
-                                Plant Identification Meet
-                            </strong>
-
-                            - bring your mystery plants in and we will do our best
+                            {{ this.description }}
                         </p>
                     </div>
                 </div>
+                {{/each}}
             </div>
         </div>
-
     </div>
 </section>
 
@@ -109,7 +55,6 @@
 
         <div class="potting_small onright">
             <div class="text">
-
                 <p>
                     <strong>
                         Benefits of membership

--- a/views/index.hbs
+++ b/views/index.hbs
@@ -18,24 +18,30 @@
         <div class="wrap-slick2">
             <div class="slick2">
                 {{#each calendar}}
+                    {{#when this.published 'eq' true}}
                 <div class="item-slick2">
+
                     <!-- Block2 -->
                     <div class="calendar_date">
+                        {{#with (lookup ../timeInfo @index)}}
                         <div class="top-bar">
-                            <h3>the {{ intToMonth this.month }} {{ this.month }} {{ ../currentMonth }}</h3>
+                            <h3>the {{this.dayText}} {{this.monthText}}</h3>
                         </div>
                         <p>
-                            ~ 6:30 pm
+                            {{this.hour}}:{{this.minute}}
+                            {{#when this.hour 'gte' 12}}PM{{/when}}
+                            {{#when this.hour 'lte' 12}}AM{{/when}}
                         </p>
+                        {{/with}}
                         <p class="meetdescription">
                             <strong>
                                 {{ this.title }}
                             </strong>
-
                             {{ this.description }}
                         </p>
                     </div>
                 </div>
+                    {{/when}}
                 {{/each}}
             </div>
         </div>
@@ -82,7 +88,7 @@
             Latest News
         </h3>
         <!-- blog post -->
-      
+
             {{#each blogs}}
 
             {{#each this}}

--- a/views/partials/header_nav_admin.hbs
+++ b/views/partials/header_nav_admin.hbs
@@ -40,6 +40,23 @@
 
             <!-- Nav Item - Pages Collapse Menu -->
             <li class="nav-item">
+                <a class="nav-link collapsed" href="#" data-toggle="collapse" data-target="#collapseCalendar" aria-expanded="true" aria-controls="collapseCalendar">
+                    <i class="fas fa-fw fa-leaf"></i>
+                    <span>Calendar</span>
+                </a>
+                <div id="collapseCalendar" class="collapse" aria-labelledby="headingCalendar" data-parent="#accordionSidebar">
+                    <div class="bg-white py-2 collapse-inner rounded">
+                        <h6 class="collapse-header">Calendar menu:</h6>
+                        <a class="collapse-item" href="/admin/calendar">This years calendar</a>
+                    </div>
+                </div>
+            </li>
+
+            <!-- Divider -->
+            <hr class="sidebar-divider">
+
+            <!-- Nav Item - Pages Collapse Menu -->
+            <li class="nav-item">
                 <a class="nav-link collapsed" href="#" data-toggle="collapse" data-target="#collapseTwo" aria-expanded="true" aria-controls="collapseTwo">
                     <i class="fas fa-fw fa-leaf"></i>
                     <span>Products</span>


### PR DESCRIPTION
Adds a 'calendar edit' page for managing the years schedule. If there are no entries for this years schedule, 12 unpublished events will be created per "2nd thursday of each month @ 7.30pm". Page gives option to edit the title, the description and publish/unpublish (makes the meeting disappear)

This PR ties the homepages calendar with the mongo data store.

No plans to add 'edit time or date' to the manage page yet, it can come in a follow up PR. 

Adds a database seeder for the 2020 schedule so far.