### PR TITLE
allow passing a file to load with our configuration

### DIFF
--- a/bin/www
+++ b/bin/www
@@ -1,11 +1,37 @@
 #!/usr/bin/env node
-
+let fs = require('fs');
+const App = require('../app');
 /**
  * Module dependencies.
  */
-var config = require('../config/config.js');
-require('../app')(config)
-    .then(null, function (err) {
-        console.log(err)
-        process.exit(1)
+
+function loadConfigFromFile(filePath) {
+    return new Promise(
+        function (resolve, reject) {
+            fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+                if (!err) {
+                    resolve(JSON.parse(data.toString()))
+                } else {
+                    reject(err)
+                }
+            })
+        }
+    )
+}
+
+let promise;
+if (process.argv.length > 2) {
+    promise = loadConfigFromFile(process.argv[2])
+} else {
+    promise = new Promise(function (resolve) {
+        resolve(require('../config/config.js'));
     });
+}
+
+promise.then(function (config) {
+    return App(config)
+        .then(null, function (err) {
+            console.log(err);
+            process.exit(1)
+        });
+});


### PR DESCRIPTION
At deploy time, a configuration file trumps environment variables.. This PR adds an optional argument to `bin/www` - a file path to a json file containing a configuration object. If not provided, the default config.js is used. 

Didn't really want env vars in the .service file as they're readable by everyone - whereas file permissions can restrict so only the user running our app can read it.