### PR TITLE
Contact info configurable

### DIFF
--- a/app.js
+++ b/app.js
@@ -74,6 +74,18 @@ function createServer(config) {
         extname: ".hbs",
         helpers: {
             intToMonth: DateUtil.intToMonth,
+            contactTwitterHandle: function () {
+                return contactInfo.twitter;
+            },
+            contactInstagramHandle: function () {
+                return contactInfo.instagram;
+            },
+            contactPinterestHandle: function () {
+                return contactInfo.pinterest;
+            },
+            contactFacebookHandle: function () {
+                return contactInfo.facebook;
+            },
             contactSocietyMobile: function () {
                 return contactInfo.mobile;
             },

--- a/app.js
+++ b/app.js
@@ -13,6 +13,7 @@ var methodOverride = require('method-override');
 const mongoose = require("mongoose");
 const bodyParser = require("body-parser");
 const stripeMod = require('stripe');
+const contactInfo = require('./config/contact');
 let DateUtil = require('./lib/dateutil');
 var cookieParser = require('cookie-parser');
 var logger = require('morgan');
@@ -73,6 +74,21 @@ function createServer(config) {
         extname: ".hbs",
         helpers: {
             intToMonth: DateUtil.intToMonth,
+            contactSocietyMobile: function () {
+                return contactInfo.mobile;
+            },
+            contactSocietyEmail: function () {
+                return contactInfo.emailAddress;
+            },
+            contactSocietyAddressHtmlFormat: function () {
+                return contactInfo.addressHtmlFormat;
+            },
+            societyAbbreviation: function () {
+                return contactInfo.abbreviation;
+            },
+            societyFullName: function () {
+                return contactInfo.fullName;
+            },
             when: function(operand_1, operator, operand_2, options) {
                 var operators = {
                     'eq': function(l,r) { return l == r; },
@@ -112,7 +128,7 @@ function createServer(config) {
     app.use(cookieParser());
 
     app.get('/about', function (req, res) {
-        res.render("about/about", { title: 'About IBCSS' });
+        res.render("about/about", { title: 'About '+contactInfo.abbreviation });
     });
 
     //sessions

--- a/config/contact.js
+++ b/config/contact.js
@@ -1,0 +1,10 @@
+module.exports = {
+    abbreviation: "ICSS",
+    mobile: "(+353) 87-2308330",
+    emailAddress: "irishcactusandsucculentsociety@gmail.com",
+    fullName: "The Irish Cactus and Succulent Society",
+    addressHtmlFormat: "Irish Cactus and Succulent Society<br />\n" +
+        "                    Dublin Botanic Gardens<br />\n" +
+        "                    Glasnevin, Dublin 9<br />\n" +
+        "                    Ireland"
+};

--- a/config/contact.js
+++ b/config/contact.js
@@ -1,4 +1,8 @@
 module.exports = {
+    twitter: "CactusSocietyIE",
+    facebook: "CactusandSucculentSocietyofIreland",
+    instagram: "",
+    pinterest: "irishcactusandsucculentsociety",
     abbreviation: "ICSS",
     mobile: "(+353) 87-2308330",
     emailAddress: "irishcactusandsucculentsociety@gmail.com",

--- a/config/contact.js
+++ b/config/contact.js
@@ -2,7 +2,7 @@ module.exports = {
     abbreviation: "ICSS",
     mobile: "(+353) 87-2308330",
     emailAddress: "irishcactusandsucculentsociety@gmail.com",
-    fullName: "The Irish Cactus and Succulent Society",
+    fullName: "Irish Cactus and Succulent Society",
     addressHtmlFormat: "Irish Cactus and Succulent Society<br />\n" +
         "                    Dublin Botanic Gardens<br />\n" +
         "                    Glasnevin, Dublin 9<br />\n" +

--- a/views/about/about.hbs
+++ b/views/about/about.hbs
@@ -3,7 +3,7 @@
         <section class="background_pages banner_about">
             <div class="about_header">
                 <h2>
-                    {{title}}
+                    About {{ societyAbbreviation }}
                 </h2>
                 <p class="moto">Learn more about the Society</p>
             </div>

--- a/views/admin/contacts/allcontacts.hbs
+++ b/views/admin/contacts/allcontacts.hbs
@@ -5,7 +5,7 @@
     <section class="banner_contact">
         <div class="onbanner">
             <h4>{{title}}</h4>
-            <h5>These are all the people who have tried to contact IBCSS, you can edit or delete.</h5>
+            <h5>These are all the people who have tried to contact {{ societyAbbreviation }}, you can edit or delete.</h5>
         </div>
     </section>
     <hr />

--- a/views/admin/dashboard.hbs
+++ b/views/admin/dashboard.hbs
@@ -1,7 +1,7 @@
 ﻿{{>header_nav_admin}}
 <!-- Content Row -->
 <div id="wrapper" class="row">
-    <h2>Welcome to the IBCSS Dashboard</h2>
+    <h2>Welcome to the {{ societyAbbreviation }} Dashboard</h2>
     </div>
     {{>footer_admin}}
 

--- a/views/index.hbs
+++ b/views/index.hbs
@@ -2,7 +2,7 @@
     <div id="index_banner">
     </div>
     <h2 class="index_header">
-        Welcome to the Irish Cactus and Succulent Society Website
+        Welcome to the {{ societyFullName}} Website
     </h2>
 </section>
 <!-- Calendar -->

--- a/views/partials/footer.hbs
+++ b/views/partials/footer.hbs
@@ -7,7 +7,7 @@
                     Get in touch
                 </h4>
                 <p>
-                    Any questions? Let us know by calling or texting <strong>(+353) 87-2308330</strong>, email<strong> info@cactusandsucculentsociety.ie</strong> or by using the form on the <strong>Contact page</strong>.
+                    Any questions? Let us know by calling or texting <strong>{{ contactSocietyMobile }}</strong>, email<strong> <a href="mailto:{{ contactSocietyEmail }}">{{ contactSocietyEmail }}</a></strong> or by using the form on the <strong>Contact page</strong>.
                 </p>
                 <!--social media - icons from fontawesome-->
                 <div class="social">
@@ -23,10 +23,7 @@
                     Address
                 </h4>
                 <p>
-                    Irish Cactus and Succulent Society<br />
-                    Dublin Botanic Gardens<br />
-                    Glasnevin, Dublin 9<br />
-                    Ireland
+                    {{{ contactSocietyAddressHtmlFormat }}}
                 </p>
             </div>
 
@@ -37,7 +34,7 @@
 
     <div class="vertical">
 
-        <span></span><p> &copy; Irish Cactus and Succulent Society</p>
+        <span></span><p> &copy; {{ societyFullName }}</p>
     </div>
     <!-- Back to top button :) -->
     <div class="btn-back-to-top" id="myBtn">

--- a/views/partials/header.hbs
+++ b/views/partials/header.hbs
@@ -3,10 +3,18 @@
     <div class="container-menu-header">
         <div class="topbar">
             <div class="topbar-social">
-                <a href="https://www.facebook.com/CactusandSucculentSocietyofIreland" class="topbar-social-item fa fa-facebook" target="_blank"></a>
-                <a href="#" class="topbar-social-item fa fa-instagram" target="_blank"></a>
-                <a href="https://twitter.com/CactusSocietyIE" class="topbar-social-item fa fa-twitter" target="_blank"></a>
-                <a href="https://www.pinterest.co.uk/irishcactusandsucculentsociety" class="topbar-social-item fa fa-pinterest-p" target="_blank"></a>
+                {{#when (contactFacebookHandle) 'noteq' ""}}
+                <a href="https://www.facebook.com/{{ contactFacebookHandle }}" class="topbar-social-item fa fa-facebook" target="_blank"></a>
+                {{/when}}
+                {{#when (contactInstagramHandle) 'noteq' ""}}
+                <a href="https://instagram.com/{{ contactInstagramHandle }}" class="topbar-social-item fa fa-instagram" target="_blank"></a>
+                {{/when}}
+                {{#when (contactTwitterHandle) 'noteq' ""}}
+                <a href="https://twitter.com/{{ contactTwitterHandle }}" class="topbar-social-item fa fa-twitter" target="_blank"></a>
+                {{/when}}
+                {{#when (contactPinterestHandle) 'noteq' ""}}
+                <a href="https://www.pinterest.ie/{{ contactPinterestHandle }}" class="topbar-social-item fa fa-pinterest-p" target="_blank"></a>
+                {{/when}}
             </div>
         </div>
 

--- a/views/partials/header.hbs
+++ b/views/partials/header.hbs
@@ -13,7 +13,7 @@
         <div class="wrap_header">
             <!-- logo -->
             <a href="/" class="logo">
-                ICSS
+                {{ societyAbbreviation }}
             </a>
             <!-- nav -->
             <div class="wrap_menu">

--- a/views/partials/header_nav_admin.hbs
+++ b/views/partials/header_nav_admin.hbs
@@ -24,7 +24,7 @@
             <a class="sidebar-brand d-flex align-items-center justify-content-center" href="">
                 <div class="sidebar-brand-icon rotate-n-15">
                 </div>
-                <div class="sidebar-brand-text mx-3">IBCSS Dashboard</div>
+                <div class="sidebar-brand-text mx-3">{{ societyAbbreviation }} Dashboard</div>
             </a>
             <!-- Divider -->
             <hr class="sidebar-divider my-0">
@@ -63,7 +63,7 @@
                 </a>
                 <div id="collapseTwo" class="collapse" aria-labelledby="headingTwo" data-parent="#accordionSidebar">
                     <div class="bg-white py-2 collapse-inner rounded">
-                        <h6 class="collapse-header">IBCSS Products:</h6>
+                        <h6 class="collapse-header">{{ societyAbbreviation }} Products:</h6>
                         <a class="collapse-item" href="/admin/createproduct">Add product</a>
                         <a class="collapse-item" href="/admin/allproducts">All products</a>
                     </div>
@@ -79,7 +79,7 @@
                 </a>
                 <div id="collapseUtilities" class="collapse" aria-labelledby="headingUtilities" data-parent="#accordionSidebar">
                     <div class="bg-white py-2 collapse-inner rounded">
-                        <h6 class="collapse-header">IBCSS Blog:</h6>
+                        <h6 class="collapse-header">{{ societyAbbreviation }} Blog:</h6>
                         <a class="collapse-item" href="/admin/createblog">Add blog post</a>
                         <a class="collapse-item" href="/admin/allblogs">All blogs</a>
                     </div>


### PR DESCRIPTION
Adds handlebars helpers to fetch contact and salutation information for the society. They can be used in templates. Currently, the values are hard coded somewhere. But they can be treated as defaults - later we can check for overrides in mongo and use those if set.

            contactTwitterHandle: societies twitter handle, or empty string
            contactInstagramHandle: societies instagram handle, or empty string
            contactPinterestHandle: societies pinterest handle, or empty string
            contactFacebookHandle: societies facebook handle, or empty string
            contactSocietyMobile: print our societies mobile number
            contactSocietyEmail: print the societys email
            contactSocietyAddressHtmlFormat: print a sanely HTML formatted address
            societyAbbreviation: abbreviation for the society (eg ICSS)
            societyFullName: ie, "Irish Cactus and Succulent Society"

The header now only shows social media accounts which have non-empty strings in the contact file